### PR TITLE
Add FeaturedAnnouncement component and integrate it into the main page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Menu, Globe } from "lucide-react";
+import FeaturedAnnouncement from "@/components/FeaturedAnnouncement";
 
 // Utility function to replace Turkish characters with English equivalents
 const replaceTurkishChars = (text: string) => {
@@ -109,22 +110,14 @@ export default function Component() {
         </div>
       </header>
 
-      {/* Featured Announcement 
-      <section className="bg-yellow-100 text-yellow-900 py-2">
-        <div className="container mx-auto text-center">
-          <a
-            href="https://www.instagram.com/dauhub"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-bold text-sm hover:underline md:text-lg"
-          >
-            {language === 'en'
-              ? 'Check out DauHub: the top Instagram humor page at EMU'
-              : 'DauHub\'ı keşfedin: Daü\'deki en iyi Instagram mizah sayfası '}
-          </a>
-        </div>
-      </section>
-      */}
+      {/* Featured Announcement */}
+      <FeaturedAnnouncement
+        show={true}
+        language={language}
+        link="https://www.instagram.com/dauhub"
+        announcementEN="Check out DauHub: the top Instagram humor page at EMU"
+        announcementTR="DauHub'ı keşfedin: Daü'deki en iyi Instagram mizah sayfası"
+      />
 
       {/* Main Content */}
       <main className="flex-1">

--- a/src/components/FeaturedAnnouncement.tsx
+++ b/src/components/FeaturedAnnouncement.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+interface FeaturedAnnouncementProps {
+  show: boolean;
+  language: "en" | "tr";
+  announcementTR: string;
+  announcementEN: string;
+  link?: string;
+}
+
+const FeaturedAnnouncement: React.FC<FeaturedAnnouncementProps> = ({
+  show,
+  language,
+  announcementTR,
+  announcementEN,
+  link,
+}) => {
+  if (!show) return null;
+  return (
+    <section className="bg-yellow-100 text-yellow-900 py-2">
+      <div className="container mx-auto text-center">
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`font-bold text-sm hover:underline md:text-lg`}
+        >
+          {language === "en" ? announcementEN : announcementTR}
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default FeaturedAnnouncement;


### PR DESCRIPTION
This pull request introduces a new `FeaturedAnnouncement` component and integrates it into the main page. The changes include creating the new component and updating the main page to use this component instead of the previous hardcoded announcement section.

### Introduction of `FeaturedAnnouncement` component:

* [`src/components/FeaturedAnnouncement.tsx`](diffhunk://#diff-fbec8b6182042f80afc66ca10857a7e63cd661039fc0c383a20567682bb17b37R1-R35): Created a new `FeaturedAnnouncement` component that accepts props for visibility, language, announcement texts, and link. This component conditionally renders an announcement section based on the provided props.

### Integration of `FeaturedAnnouncement` component:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR5): Imported the `FeaturedAnnouncement` component and replaced the previously commented-out hardcoded announcement section with the new component, passing the necessary props to it. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR5) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL112-R120)

This pull request closes #2 